### PR TITLE
Relax RSpec version restrictions

### DIFF
--- a/rspec-search-and-destroy.gemspec
+++ b/rspec-search-and-destroy.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency('rspec', '>= 2.14.0')
+  gem.add_dependency('rspec', '~> 2.12')
+
+  gem.add_development_dependency('rspec', '~> 2.14')
   gem.add_development_dependency('aruba')
 end


### PR DESCRIPTION
RSpec 2.12 introduced the sorting block we use, so let's assume that's
the earliest we can go. Stick to a newish RSpec for our own tests
though.

Closes #13
