### PR TITLE
Don't run `before :all` blocks when all the examples are disabled

### DIFF
--- a/features/before_all_blocks_are_disabled.feature
+++ b/features/before_all_blocks_are_disabled.feature
@@ -1,0 +1,41 @@
+Feature: `before(:all)` blocks are disabled when all of the examples are also disabled
+
+Scenario: Run it
+  Given a file named "spec/spec_helper.rb" with:
+    """ruby
+    require 'rspec-sad'
+
+    RSpec.configure do |config|
+      RSpecSearchAndDestroy.configure(config)
+    end
+    """
+  And a file named "spec/before_all_spec.rb" with:
+    """ruby
+    require 'spec_helper'
+
+    describe 'Tests that have before :all' do
+      context do
+        before(:all) { puts 'example 1 - before :all' }
+        it 'leaves bad global state' do
+          $global_state = true
+          expect($global_state).to be true
+        end
+      end
+
+      context do
+        before(:all) { puts 'example 2 - before :all' }
+        it do
+          expect(true).to be true
+        end
+      end
+
+      context do
+        before(:all) { puts 'example 3 - before :all' }
+        it 'relies on global state' do
+          expect($global_state).to be false
+        end
+      end
+    end
+    """
+  When I run `rspec-sad`
+  Then the output should contain "example 2 - before :all" 1 time

--- a/features/support/steps.rb
+++ b/features/support/steps.rb
@@ -1,0 +1,4 @@
+Then(/^the output should contain "(.*?)" (\d+) times?$/) do |expected_output, expected_count|
+  actual_count = all_output.scan(expected_output).length
+  expect(actual_count).to eql expected_count.to_i
+end

--- a/lib/rspec-sad.rb
+++ b/lib/rspec-sad.rb
@@ -11,6 +11,8 @@ module RSpecSearchAndDestroy
     source = LocationSource.new
     if source.enabled?
       ordering = ReorderAndFilter.new(source)
+
+      config.files_or_directories_to_run = source.example_locations_to_run
       config.order_examples(&ordering.block)
     end
   end


### PR DESCRIPTION
RSpec will already avoid calling `before :all` when all of the
examples are disabled, but only when it knows that they have been
filtered. We can explictly filter to share this functionality.

Closes #12
