### PR TITLE
Allow running RSpec even when not run through SAD

### DIFF
--- a/features/running_rspec_without_sad.feature
+++ b/features/running_rspec_without_sad.feature
@@ -1,0 +1,10 @@
+Feature: Running RSpec when SAD is configured
+
+Scenario: Run it
+  Given a configured spec/spec_helper.rb
+  And a file named "spec/empty_spec.rb" with:
+    """ruby
+    require 'spec_helper'
+    """
+  When I run `rspec`
+  Then the exit status should be 0

--- a/lib/rspec-search-and-destroy/order_formatter.rb
+++ b/lib/rspec-search-and-destroy/order_formatter.rb
@@ -3,8 +3,10 @@ require 'rspec/core/formatters/base_formatter'
 module RSpecSearchAndDestroy
   class OrderFormatter < RSpec::Core::Formatters::BaseFormatter
     def stop
-      File.open(filename, 'wb') do |f|
-        Marshal.dump(results, f)
+      if enabled?
+        File.open(filename, 'wb') do |f|
+          Marshal.dump(results, f)
+        end
       end
 
       super
@@ -12,8 +14,12 @@ module RSpecSearchAndDestroy
 
     private
 
+    def enabled?
+      filename
+    end
+
     def filename
-      ENV['RSPEC_SAD_RESULTS'] or raise "No result filename provided"
+      ENV['RSPEC_SAD_RESULTS']
     end
 
     def results


### PR DESCRIPTION
This allows the user to configure SAD once and then leave it in the
configuration file.

Closes #19
